### PR TITLE
Fix 0.03125 arithmetic

### DIFF
--- a/js/bouncetoolsDisplay.js
+++ b/js/bouncetoolsDisplay.js
@@ -67,8 +67,8 @@ function m_bounce()
 	var wrongInputAngle = 0;
 	var wrongInputFloor = 0;
 	var wrongInputCeiling = 0;
-	var floor_height = document.getElementById("txt_height").value + 0.03125;
-	var ceiling_gap = document.getElementById("txt_height_ceiling").value - 0.03125;
+	var floor_height = document.getElementById("txt_height").value;
+	var ceiling_gap = document.getElementById("txt_height_ceiling").value;
 	var nearestAngle = document.getElementById("txt_nearestAngle").value;
 
 	document.getElementById("bounceInfo").innerHTML = "";
@@ -186,6 +186,10 @@ function m_bounce()
 		wrongInputAngle = 1;
 		//return 0;
 	}
+	
+	// Deal with adding and subtracting 0.03125
+	floor_height = parseInt(floor_height, 10) + 0.03125;
+	ceiling_gap -= 0.03125;
 	
 //console.log("h_silly:" + h_silly)
 //console.log("h_greater:" + h_greater)


### PR DESCRIPTION
Assuming the adding/subtraction of 0.03125 in https://github.com/Graru1/Graru1.github.io/commit/f8b41253a3e33784d30a39695f5837dfde8244fb did not introduce any logic errors, this PR fixes two issues:

1. floor_height now uses the arithmetic operator instead of concatenation operator by treating floor_height as a number type instead of string (parseInt).
2. ceiling_gap subtraction is moved after the c_undefined check. Currently ceiling_gap will never be equal to an empty string '', since the empty value string is being treated as 0 (0 - 0.03125). This means that `(c_greater) && (!wrongInputFloor) && (!c_undefined)` condition evaluates true even when there's no user-specified ceiling height. Moving the subtraction to after this check and not during ceiling_gap's assignment fixes this. This also fixes the >=63 ceiling height check.